### PR TITLE
Added sorting based on JEI Ingredient List

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -68,9 +68,23 @@ minecraft {
     }
 }
 
+repositories {
+    maven {
+        // location of the maven that hosts JEI files
+        name = "Progwml6 maven"
+        url = "https://dvs1.progwml6.com/files/maven/"
+    }
+    maven {
+        // location of a maven mirror for JEI files, as a fallback
+        name = "ModMaven"
+        url = "https://modmaven.k-4u.nl"
+    }
+}
 
 dependencies {
     minecraft "net.minecraftforge:forge:${MC_VERSION}-${FORGE_VERSION}"
+    compileOnly fg.deobf("mezz.jei:jei-${MC_VERSION}:${JEI_VERSION}:api")
+    runtimeOnly fg.deobf("mezz.jei:jei-${MC_VERSION}:${JEI_VERSION}")
 }
 
 task makeChangelog(type: se.bjurr.gitchangelog.plugin.gradle.GitChangelogTask) {

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,8 +1,9 @@
 # Sets default memory used for gradle commands. Can be overridden by user or command line properties.
 # This is required to provide enough memory for the Minecraft decompilation process.
-org.gradle.jvmargs=-Xmx3G
+org.gradle.jvmargs=-Xmx6G
 org.gradle.daemon=false
-MC_VERSION=1.16.1
-FORGE_VERSION=32.0.75
+MC_VERSION=1.16.5
+FORGE_VERSION=36.1.0
 MCP_CHANNEL=snapshot
 MCP_MAPPINGS=20200514-1.16
+JEI_VERSION=7.6.4.87

--- a/src/main/java/cpw/mods/inventorysorter/JeiInventorySorterPlugin.java
+++ b/src/main/java/cpw/mods/inventorysorter/JeiInventorySorterPlugin.java
@@ -1,5 +1,6 @@
 package cpw.mods.inventorysorter;
 
+import com.google.common.collect.Multiset;
 import mezz.jei.api.IModPlugin;
 import mezz.jei.api.JeiPlugin;
 import mezz.jei.api.constants.VanillaRecipeCategoryUid;
@@ -51,6 +52,9 @@ public class JeiInventorySorterPlugin implements IModPlugin {
     @Nullable
     public static Collection<IIngredientType<?>> ingredientTypes;
 
+    @Nullable
+    public static Multiset<ItemStack> test;
+
     @Override
     public void onRuntimeAvailable(IJeiRuntime jeiRuntime) {
         System.out.println("onRuntimeAvailable");
@@ -60,6 +64,8 @@ public class JeiInventorySorterPlugin implements IModPlugin {
 //        Collection<IIngredientType> ingredientTypes = ingredientManager.getRegisteredIngredientTypes();
 
         Collection<?> allIngredients = new ArrayList<>();
+
+        JeiInventorySorterPlugin.test = (Multiset<ItemStack>) ingredientManager.getAllIngredients(VanillaTypes.ITEM);
 
         ingredientTypes = ingredientManager.getRegisteredIngredientTypes();
 

--- a/src/main/java/cpw/mods/inventorysorter/JeiInventorySorterPlugin.java
+++ b/src/main/java/cpw/mods/inventorysorter/JeiInventorySorterPlugin.java
@@ -50,7 +50,7 @@ public class JeiInventorySorterPlugin implements IModPlugin {
                 }
                 JeiInventorySorterPlugin.allIngredients = ingredientList;
             } catch (Exception e) {
-                InventorySorter.LOGGER.warn("JEI is not installed, sorting will default to stack size.", e);
+                InventorySorter.LOGGER.warn("Something went wrong while initializing JeiInventorySorterPlugin.", e);
             }
         }
     }

--- a/src/main/java/cpw/mods/inventorysorter/JeiInventorySorterPlugin.java
+++ b/src/main/java/cpw/mods/inventorysorter/JeiInventorySorterPlugin.java
@@ -1,0 +1,80 @@
+package cpw.mods.inventorysorter;
+
+import mezz.jei.api.IModPlugin;
+import mezz.jei.api.JeiPlugin;
+import mezz.jei.api.constants.VanillaRecipeCategoryUid;
+import mezz.jei.api.constants.VanillaTypes;
+import mezz.jei.api.ingredients.IIngredientType;
+import mezz.jei.api.ingredients.IIngredients;
+import mezz.jei.api.recipe.IRecipeManager;
+import mezz.jei.api.registration.IRecipeCatalystRegistration;
+import mezz.jei.api.registration.IRecipeCategoryRegistration;
+import mezz.jei.api.registration.IRecipeRegistration;
+import mezz.jei.api.registration.IRecipeTransferRegistration;
+import mezz.jei.api.registration.ISubtypeRegistration;
+import mezz.jei.api.registration.IVanillaCategoryExtensionRegistration;
+import mezz.jei.api.runtime.IIngredientManager;
+import mezz.jei.api.runtime.IJeiRuntime;
+import mezz.jei.api.runtime.IRecipesGui;
+import mezz.jei.api.gui.ingredient.IGuiIngredient;
+
+import net.minecraft.client.Minecraft;
+import net.minecraft.client.gui.screen.inventory.ContainerScreen;
+import net.minecraft.item.Item;
+import net.minecraft.item.ItemStack;
+import net.minecraft.item.crafting.Ingredient;
+import net.minecraft.item.crafting.RecipeManager;
+import net.minecraft.util.NonNullList;
+import net.minecraft.util.ResourceLocation;
+import net.minecraft.world.World;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+
+import java.util.*;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+@JeiPlugin
+public class JeiInventorySorterPlugin implements IModPlugin {
+    private static final ResourceLocation ID = new ResourceLocation("inventorysorter");
+
+    @Nullable
+    public static IIngredientManager ingredientManager;
+
+    @Nullable
+    public static IJeiRuntime jeiRuntime;
+
+    @Nullable
+    public static Collection<?> itemList;
+
+    @Nullable
+    public static Collection<IIngredientType<?>> ingredientTypes;
+
+    @Override
+    public void onRuntimeAvailable(IJeiRuntime jeiRuntime) {
+        System.out.println("onRuntimeAvailable");
+        JeiInventorySorterPlugin.jeiRuntime = jeiRuntime;
+        JeiInventorySorterPlugin.ingredientManager = jeiRuntime.getIngredientManager();
+
+//        Collection<IIngredientType> ingredientTypes = ingredientManager.getRegisteredIngredientTypes();
+
+        Collection<?> allIngredients = new ArrayList<>();
+
+        ingredientTypes = ingredientManager.getRegisteredIngredientTypes();
+
+        for (IIngredientType<?> ingredientType : ingredientTypes) {
+            Collection<?> ingredientList = ingredientManager.getAllIngredients(ingredientType);
+
+            allIngredients = Stream.concat(allIngredients.stream(), ingredientList.stream()).collect(Collectors.toList());
+        }
+
+        JeiInventorySorterPlugin.itemList = allIngredients;
+    }
+
+    @Nonnull
+    @Override
+    public ResourceLocation getPluginUid() {
+        return ID;
+    }
+}

--- a/src/main/java/cpw/mods/inventorysorter/SortingHandler.java
+++ b/src/main/java/cpw/mods/inventorysorter/SortingHandler.java
@@ -125,6 +125,9 @@ public enum SortingHandler implements Consumer<ContainerContext>
         Collection<?> items = jeiInventorySorterPlugin.itemList;
         System.out.println(items.toString());
 
+        Multiset<ItemStack> test = jeiInventorySorterPlugin.test;
+        System.out.println(test.toString());
+
 //        System.out.println(jeiInternalPlugin.ingredientManager.getAllIngredients(VanillaTypes.ITEM));
 
         final ResourceLocation containerTypeName = lookupContainerTypeName(context.player.container);
@@ -139,6 +142,10 @@ public enum SortingHandler implements Consumer<ContainerContext>
         try
         {
             itemsIterator = Multisets.copyHighestCountFirst(itemcounts).entrySet().iterator();
+            System.out.println(itemcounts.toString());
+            for(ItemStackHolder itemStack: itemcounts) {
+                System.out.println(itemStack.is.toString());
+            }
         }
         catch (Exception e)
         {

--- a/src/main/java/cpw/mods/inventorysorter/SortingHandler.java
+++ b/src/main/java/cpw/mods/inventorysorter/SortingHandler.java
@@ -19,17 +19,16 @@
 package cpw.mods.inventorysorter;
 
 import com.google.common.collect.*;
-import mezz.jei.api.ingredients.IIngredientType;
-import net.minecraft.inventory.*;
+import net.minecraft.inventory.CraftingInventory;
 import net.minecraft.inventory.container.Container;
 import net.minecraft.inventory.container.PlayerContainer;
 import net.minecraft.inventory.container.Slot;
-import net.minecraft.item.*;
+import net.minecraft.item.ItemStack;
 import net.minecraft.util.ResourceLocation;
-import org.apache.logging.log4j.*;
+import net.minecraftforge.fml.ModList;
+import org.apache.logging.log4j.Level;
 
-import java.util.Collection;
-import java.util.function.*;
+import java.util.function.Consumer;
 
 /**
  * @author cpw
@@ -61,7 +60,6 @@ public enum SortingHandler implements Consumer<ContainerContext>
 
     private void distributeInventory(final ContainerContext context, final Multiset<ItemStackHolder> itemcounts)
     {
-        System.out.println("distributeInventory");
         CraftingInventory ic = (CraftingInventory) context.slot.inventory;
         Multiset<ItemStackHolder> slotCounts = TreeMultiset.create(new InventoryHandler.ItemStackComparator());
         for (int x=0; x<ic.getWidth(); x++)
@@ -116,20 +114,6 @@ public enum SortingHandler implements Consumer<ContainerContext>
 
     private void compactInventory(final ContainerContext context, final Multiset<ItemStackHolder> itemcounts)
     {
-        System.out.println("compactInventory");
-        final JeiInventorySorterPlugin jeiInventorySorterPlugin = new JeiInventorySorterPlugin();
-
-        Collection<IIngredientType<?>> ingredientTypes = jeiInventorySorterPlugin.ingredientTypes;
-        System.out.println(ingredientTypes.toString());
-
-        Collection<?> items = jeiInventorySorterPlugin.itemList;
-        System.out.println(items.toString());
-
-        Multiset<ItemStack> test = jeiInventorySorterPlugin.test;
-        System.out.println(test.toString());
-
-//        System.out.println(jeiInternalPlugin.ingredientManager.getAllIngredients(VanillaTypes.ITEM));
-
         final ResourceLocation containerTypeName = lookupContainerTypeName(context.player.container);
         InventorySorter.INSTANCE.lastContainerType = containerTypeName;
         if (InventorySorter.INSTANCE.containerblacklist.contains(containerTypeName)) {
@@ -141,10 +125,10 @@ public enum SortingHandler implements Consumer<ContainerContext>
         final UnmodifiableIterator<Multiset.Entry<ItemStackHolder>> itemsIterator;
         try
         {
-            itemsIterator = Multisets.copyHighestCountFirst(itemcounts).entrySet().iterator();
-            System.out.println(itemcounts.toString());
-            for(ItemStackHolder itemStack: itemcounts) {
-                System.out.println(itemStack.is.toString());
+            if (ModList.get().isLoaded("jei")) {
+                itemsIterator = JeiInventorySorterPlugin.sortItems(itemcounts);
+            } else {
+                itemsIterator = Multisets.copyHighestCountFirst(itemcounts).entrySet().iterator();
             }
         }
         catch (Exception e)

--- a/src/main/java/cpw/mods/inventorysorter/SortingHandler.java
+++ b/src/main/java/cpw/mods/inventorysorter/SortingHandler.java
@@ -18,8 +18,8 @@
 
 package cpw.mods.inventorysorter;
 
-import com.google.common.base.*;
 import com.google.common.collect.*;
+import mezz.jei.api.ingredients.IIngredientType;
 import net.minecraft.inventory.*;
 import net.minecraft.inventory.container.Container;
 import net.minecraft.inventory.container.PlayerContainer;
@@ -28,7 +28,7 @@ import net.minecraft.item.*;
 import net.minecraft.util.ResourceLocation;
 import org.apache.logging.log4j.*;
 
-import javax.annotation.*;
+import java.util.Collection;
 import java.util.function.*;
 
 /**
@@ -61,6 +61,7 @@ public enum SortingHandler implements Consumer<ContainerContext>
 
     private void distributeInventory(final ContainerContext context, final Multiset<ItemStackHolder> itemcounts)
     {
+        System.out.println("distributeInventory");
         CraftingInventory ic = (CraftingInventory) context.slot.inventory;
         Multiset<ItemStackHolder> slotCounts = TreeMultiset.create(new InventoryHandler.ItemStackComparator());
         for (int x=0; x<ic.getWidth(); x++)
@@ -112,8 +113,20 @@ public enum SortingHandler implements Consumer<ContainerContext>
             context.player.openContainer.getSlot(slot).onSlotChanged();
         }
     }
+
     private void compactInventory(final ContainerContext context, final Multiset<ItemStackHolder> itemcounts)
     {
+        System.out.println("compactInventory");
+        final JeiInventorySorterPlugin jeiInventorySorterPlugin = new JeiInventorySorterPlugin();
+
+        Collection<IIngredientType<?>> ingredientTypes = jeiInventorySorterPlugin.ingredientTypes;
+        System.out.println(ingredientTypes.toString());
+
+        Collection<?> items = jeiInventorySorterPlugin.itemList;
+        System.out.println(items.toString());
+
+//        System.out.println(jeiInternalPlugin.ingredientManager.getAllIngredients(VanillaTypes.ITEM));
+
         final ResourceLocation containerTypeName = lookupContainerTypeName(context.player.container);
         InventorySorter.INSTANCE.lastContainerType = containerTypeName;
         if (InventorySorter.INSTANCE.containerblacklist.contains(containerTypeName)) {


### PR DESCRIPTION
If JEI is also installed, the sorting order will be the same as the order of items in the JEI menu.
If JEI is not installed, the sorting will default back to stack size.

A setting to change the "mode" could also be added if deemed necessary...