### PR TITLE
Fix Container Conflicts

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -27,6 +27,8 @@ group= 'cpw.mods'
 archivesBaseName = 'inventorysorter'
 java.toolchain.languageVersion = JavaLanguageVersion.of(17)
 
+version = "19.0.1"
+
 //reckon {
 //    scopeFromProp()
 //    stageFromProp('ms', 'final')

--- a/gradle.properties
+++ b/gradle.properties
@@ -2,7 +2,7 @@
 # This is required to provide enough memory for the Minecraft decompilation process.
 org.gradle.jvmargs=-Xmx3G
 org.gradle.daemon=false
-MC_VERSION=1.18
-FORGE_VERSION=38.0.4
+MC_VERSION=1.18.2
+FORGE_VERSION=40.1.67
 MCP_CHANNEL=official
 MCP_MAPPINGS=1.18

--- a/src/main/java/cpw/mods/inventorysorter/ConfigClient.java
+++ b/src/main/java/cpw/mods/inventorysorter/ConfigClient.java
@@ -1,0 +1,35 @@
+package cpw.mods.inventorysorter;
+
+import net.minecraft.resources.ResourceLocation;
+import net.minecraftforge.common.ForgeConfigSpec;
+import net.minecraftforge.registries.ForgeRegistries;
+import org.apache.commons.lang3.tuple.Pair;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+
+public class ConfigClient {
+
+    static final ConfigClient CONFIG;
+    static final ForgeConfigSpec CLIENT_SPEC;
+
+    static {
+        Pair<ConfigClient, ForgeConfigSpec> conf = new ForgeConfigSpec.Builder().configure(ConfigClient::new);
+        CONFIG = conf.getLeft();
+        CLIENT_SPEC = conf.getRight();
+    }
+
+    final ForgeConfigSpec.ConfigValue<List<? extends String>> containerBlacklistClient;
+
+    private ConfigClient(ForgeConfigSpec.Builder builder) {
+        builder.comment("Inventory sorter blacklists");
+        builder.push("blacklists");
+        containerBlacklistClient = builder
+                .comment("Container blacklist on Client")
+                .translation("inventorysorter.config.containerblacklistclient")
+                .defineList("containerBlacklistClient", ArrayList::new, value -> ForgeRegistries.CONTAINERS.containsKey(new ResourceLocation(Objects.toString(value))));
+        builder.pop();
+    }
+
+}

--- a/src/main/java/cpw/mods/inventorysorter/ConfigClient.java
+++ b/src/main/java/cpw/mods/inventorysorter/ConfigClient.java
@@ -28,7 +28,7 @@ public class ConfigClient {
         containerBlacklistClient = builder
                 .comment("Container blacklist on Client")
                 .translation("inventorysorter.config.containerblacklistclient")
-                .defineList("containerBlacklistClient", ArrayList::new, value -> ForgeRegistries.CONTAINERS.containsKey(new ResourceLocation(Objects.toString(value))));
+                .defineList("containerBlacklistClient", ArrayList::new, t -> true);
         builder.pop();
     }
 

--- a/src/main/java/cpw/mods/inventorysorter/InventorySorter.java
+++ b/src/main/java/cpw/mods/inventorysorter/InventorySorter.java
@@ -63,6 +63,7 @@ public class InventorySorter
     boolean debugLog;
     final Set<String> slotblacklist = new HashSet<>();
     final Set<ResourceLocation> containerblacklist = new HashSet<>();
+    final Set<ResourceLocation> containerBlacklistClient = new HashSet<>();
     boolean configLoaded = false;
 
     public InventorySorter() {
@@ -73,6 +74,7 @@ public class InventorySorter
         bus.addListener(this::handleimc);
         bus.addListener(this::onConfigLoad);
         ModLoadingContext.get().registerConfig(ModConfig.Type.SERVER, Config.SPEC);
+        ModLoadingContext.get().registerConfig(ModConfig.Type.CLIENT, ConfigClient.CLIENT_SPEC);
 
         MinecraftForge.EVENT_BUS.addListener(this::onServerStarting);
     }
@@ -108,6 +110,7 @@ public class InventorySorter
         if (!configLoaded) return;
         Config.CONFIG.containerBlacklist.set(containerblacklist.stream().map(Objects::toString).collect(Collectors.toList()));
         Config.CONFIG.slotBlacklist.set(new ArrayList<>(slotblacklist));
+        ConfigClient.CONFIG.containerBlacklistClient.set(containerBlacklistClient.stream().map(Objects::toString).collect(Collectors.toList()));
     }
 
     private void preinit(FMLCommonSetupEvent evt) {
@@ -123,6 +126,8 @@ public class InventorySorter
         this.slotblacklist.addAll(Config.CONFIG.slotBlacklist.get());
         this.containerblacklist.clear();
         this.containerblacklist.addAll(Config.CONFIG.containerBlacklist.get().stream().map(ResourceLocation::new).collect(Collectors.toSet()));
+        this.containerBlacklistClient.clear();
+        this.containerBlacklistClient.addAll(ConfigClient.CONFIG.containerBlacklistClient.get().stream().map(ResourceLocation::new).collect(Collectors.toSet()));
     }
 
     boolean wheelModConflicts() {

--- a/src/main/java/cpw/mods/inventorysorter/KeyHandler.java
+++ b/src/main/java/cpw/mods/inventorysorter/KeyHandler.java
@@ -23,6 +23,7 @@ import net.minecraft.client.gui.screens.inventory.AbstractContainerScreen;
 import net.minecraft.client.gui.screens.inventory.CreativeModeInventoryScreen;
 import net.minecraft.client.KeyMapping;
 import com.mojang.blaze3d.platform.InputConstants;
+import net.minecraft.resources.ResourceLocation;
 import net.minecraft.world.inventory.Slot;
 import net.minecraftforge.client.ClientRegistry;
 import net.minecraftforge.client.event.ScreenEvent;
@@ -99,6 +100,14 @@ public class KeyHandler
         if (!(gui instanceof AbstractContainerScreen && !(gui instanceof CreativeModeInventoryScreen))) {
             return;
         }
+
+        // Container Blacklist Validation on Client
+        ResourceLocation containerTypeName = ((AbstractContainerScreen<?>) gui).getMenu().getType().getRegistryName();
+        if(InventorySorter.INSTANCE.containerBlacklistClient.contains(containerTypeName)) {
+            InventorySorter.INSTANCE.debugLog("Container {} blacklisted", ()->new String[] {containerTypeName.toString()});
+            return;
+        }
+
         final AbstractContainerScreen guiContainer = (AbstractContainerScreen) gui;
         Slot slot = guiContainer.getSlotUnderMouse();
         if (!ContainerContext.validSlot(slot)) {


### PR DESCRIPTION
This commit should provide a way to fix issues like #140 by adding `ae2:craftingterm` to **containerBlacklistClient** in `inventorysort-client.toml`.

I'm not good at Git, and I have seemed to mess it up. :(

#140: Actually in DW20 1.18, the Crafting Terminal container is modified to `ae2wtlib:craftingterm`.