### PR TITLE
Fix Middle Click Swallowing on AE2 Fake Slots

### DIFF
--- a/src/main/java/cpw/mods/inventorysorter/ContainerContext.java
+++ b/src/main/java/cpw/mods/inventorysorter/ContainerContext.java
@@ -3,6 +3,7 @@ package cpw.mods.inventorysorter;
 import com.google.common.collect.*;
 import net.minecraft.world.inventory.AbstractContainerMenu;
 import net.minecraft.world.inventory.Slot;
+import net.minecraftforge.items.SlotItemHandler;
 import org.apache.logging.log4j.*;
 
 import java.util.*;
@@ -26,6 +27,9 @@ class ContainerContext
     static boolean validSlot(Slot slot) {
         // Skip slots without an inventory - they're probably dummy slots
         return slot != null && slot.container != null
+                // Skip slots where the inventory has no slots, these are probably dummies too.
+                // Since SlotItemHandler also uses empty fake containers, whitelist that explicitly.
+                && (slot instanceof SlotItemHandler || slot.container.getContainerSize() > 0)
                 // Skip blacklisted slots
                 && !InventorySorter.INSTANCE.slotblacklist.contains(slot.getClass().getName());
     }


### PR DESCRIPTION
AE2's fake slot return a non-null container because some *other* inventory sorting / mouse tweak mods will crash if we do.

This changes the current check that only skips slots if they have a null container to also skip slots that do have a container but that container's size is 0.

Since SlotItemHandler also uses an empty fake container and I do not know if this mod works correctly for those slots, I explicitly skip my new check for that type of slot.
