### PR TITLE
fix: #152 #121 #123 (partial) #119 #150

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -10,6 +10,7 @@ buildscript {
         classpath group: 'net.minecraftforge.gradle', name: 'ForgeGradle', version: '5.1.+', changing: true
     }
 }
+
 plugins {
     id 'com.matthewprenger.cursegradle' version '1.4.0'
     id 'se.bjurr.gitchangelog.git-changelog-gradle-plugin' version '1.71.4'
@@ -33,7 +34,7 @@ java.toolchain.languageVersion = JavaLanguageVersion.of(17)
 version = grgit.describe(longDescr: true).split('-').with { "${it[0]}.${it[1]}" }
 
 minecraft {
-    mappings channel: MCP_CHANNEL, version: MCP_MAPPINGS
+    mappings channel: "official", version: MC_VERSION
     runs {
         client {
             workingDirectory project.file('run')
@@ -58,7 +59,7 @@ minecraft {
             property 'forge.logging.noansi', 'false'
             ideaModule "${project.name}.main"
         }
-        
+
         data {
             workingDirectory project.file('run')
             property 'forge.logging.markers', 'SCAN'

--- a/gradle.properties
+++ b/gradle.properties
@@ -2,7 +2,5 @@
 # This is required to provide enough memory for the Minecraft decompilation process.
 org.gradle.jvmargs=-Xmx3G
 org.gradle.daemon=false
-MC_VERSION=1.18
-FORGE_VERSION=38.0.4
-MCP_CHANNEL=official
-MCP_MAPPINGS=1.18
+MC_VERSION=1.18.2
+FORGE_VERSION=40.1.84

--- a/src/main/java/cpw/mods/inventorysorter/ContainerContext.java
+++ b/src/main/java/cpw/mods/inventorysorter/ContainerContext.java
@@ -3,6 +3,7 @@ package cpw.mods.inventorysorter;
 import com.google.common.collect.*;
 import net.minecraft.world.inventory.AbstractContainerMenu;
 import net.minecraft.world.inventory.Slot;
+import net.minecraftforge.items.SlotItemHandler;
 import org.apache.logging.log4j.*;
 
 import java.util.*;
@@ -26,6 +27,9 @@ class ContainerContext
     static boolean validSlot(Slot slot) {
         // Skip slots without an inventory - they're probably dummy slots
         return slot != null && slot.container != null
+                // Skip slots where the inventory has no slots, these are probably dummies too.
+                // Since SlotItemHandler also uses empty fake containers, whitelist that explicitly.
+                && (slot instanceof SlotItemHandler || slot.container.getContainerSize() > 0)
                 // Skip blacklisted slots
                 && !InventorySorter.INSTANCE.slotblacklist.contains(slot.getClass().getName());
     }

--- a/src/main/java/cpw/mods/inventorysorter/InventorySorterCommand.java
+++ b/src/main/java/cpw/mods/inventorysorter/InventorySorterCommand.java
@@ -26,8 +26,8 @@ import net.minecraft.commands.SharedSuggestionProvider;
 
 public class InventorySorterCommand {
     public static void register(final CommandDispatcher<CommandSourceStack> dispatcher) {
-        final LiteralArgumentBuilder<CommandSourceStack> invsorterBuilder = Commands.literal("invsorter").
-                requires(cs->cs.hasPermission(1));
+        final LiteralArgumentBuilder<CommandSourceStack> invsorterBuilder = Commands.literal("invsorter")
+                        .requires(cs->cs.hasPermission(1));
 
         Stream.of(CommandAction.values()).forEach(a->invsorterBuilder.then(a.getCommand()));
         invsorterBuilder.executes(InventorySorterCommand::help);
@@ -35,7 +35,7 @@ public class InventorySorterCommand {
     }
 
     private static int help(final CommandContext<CommandSourceStack> context) {
-        context.getSource().sendFailure(new TranslatableComponent("inventorysorter.commands.inventorysorter.usage"));
+        context.getSource().sendSuccess(new TranslatableComponent("inventorysorter.commands.inventorysorter.usage"), false);
         return 0;
     }
 
@@ -59,7 +59,8 @@ public class InventorySorterCommand {
             final Optional<ArgumentBuilder<CommandSourceStack, ?>> argBuilder = argumentSupplier.stream()
                     .<ArgumentBuilder<CommandSourceStack, ?>>map(TypedArgumentHandler::build)
                     .reduce(ArgumentBuilder::then);
-            ifPresentOrElse(argBuilder, b -> builder.then(b.executes(this.action::applyAsInt)), ()->builder.executes(this.action::applyAsInt));
+
+            argBuilder.ifPresentOrElse(b -> builder.then(b.executes(this.action::applyAsInt)), ()->builder.executes(this.action::applyAsInt));
         }
 
         public LiteralArgumentBuilder<CommandSourceStack> getCommand() {
@@ -68,7 +69,6 @@ public class InventorySorterCommand {
             addArguments(base);
             return base;
         }
-
     }
 
     public static class Arguments {
@@ -125,14 +125,4 @@ public class InventorySorterCommand {
             return EXAMPLES;
         }
     }
-
-
-    public static <T> void ifPresentOrElse(Optional<T> optional, Consumer<? super T> action, Runnable emptyAction) {
-        if (optional.isPresent()) {
-            action.accept(optional.get());
-        } else {
-            emptyAction.run();
-        }
-    }
-
 }

--- a/src/main/java/cpw/mods/inventorysorter/KeyHandler.java
+++ b/src/main/java/cpw/mods/inventorysorter/KeyHandler.java
@@ -18,12 +18,15 @@
 
 package cpw.mods.inventorysorter;
 
+import net.minecraft.client.Minecraft;
 import net.minecraft.client.gui.screens.Screen;
 import net.minecraft.client.gui.screens.inventory.AbstractContainerScreen;
 import net.minecraft.client.gui.screens.inventory.CreativeModeInventoryScreen;
 import net.minecraft.client.KeyMapping;
 import com.mojang.blaze3d.platform.InputConstants;
+import net.minecraft.client.multiplayer.MultiPlayerGameMode;
 import net.minecraft.world.inventory.Slot;
+import net.minecraft.world.level.GameType;
 import net.minecraftforge.client.ClientRegistry;
 import net.minecraftforge.client.event.ScreenEvent;
 import net.minecraftforge.client.settings.KeyConflictContext;
@@ -95,19 +98,27 @@ public class KeyHandler
     }
 
     private <T extends ScreenEvent> void onInputEvent(T evt, BiPredicate<KeyMapping, T> kbTest) {
-        final Screen gui = evt.getScreen();
-        if (!(gui instanceof AbstractContainerScreen && !(gui instanceof CreativeModeInventoryScreen))) {
+        // Don't sort on spectator
+        MultiPlayerGameMode gameMode = Minecraft.getInstance().gameMode;
+        if (gameMode != null && gameMode.getPlayerMode() == GameType.SPECTATOR) {
             return;
         }
-        final AbstractContainerScreen guiContainer = (AbstractContainerScreen) gui;
+
+        final Screen gui = evt.getScreen();
+        if (!(gui instanceof final AbstractContainerScreen<?> guiContainer && !(gui instanceof CreativeModeInventoryScreen))) {
+            return;
+        }
+
         Slot slot = guiContainer.getSlotUnderMouse();
         if (!ContainerContext.validSlot(slot)) {
             InventorySorter.LOGGER.log(Level.DEBUG, "Skipping action handling for blacklisted slot");
             return;
         }
+
         final Optional<Action> action = keyBindingMap.entrySet().stream().filter(e -> kbTest.test(e.getKey(), evt)).
                 map(Map.Entry::getValue).findFirst();
-        if (!action.isPresent()) return;
+
+        if (action.isEmpty()) return;
 
         final Action triggeredAction = action.get();
         if (triggeredAction.isActive())

--- a/src/main/java/cpw/mods/inventorysorter/ScrollWheelHandler.java
+++ b/src/main/java/cpw/mods/inventorysorter/ScrollWheelHandler.java
@@ -20,7 +20,6 @@ package cpw.mods.inventorysorter;
 
 import net.minecraft.world.inventory.Slot;
 
-import javax.annotation.*;
 import java.util.*;
 import java.util.function.*;
 import java.util.stream.*;
@@ -31,8 +30,7 @@ import net.minecraft.world.item.ItemStack;
 /**
  * @author cpw
  */
-public enum ScrollWheelHandler implements Consumer<ContainerContext>
-{
+public enum ScrollWheelHandler implements Consumer<ContainerContext> {
     ONEITEMIN(-1), ONEITEMOUT(1);
 
     private final int moveAmount;
@@ -41,7 +39,7 @@ public enum ScrollWheelHandler implements Consumer<ContainerContext>
     {
         this.moveAmount = amount;
     }
-    @Nullable
+
     @Override
     public void accept(ContainerContext context)
     {

--- a/src/main/java/cpw/mods/inventorysorter/SortingHandler.java
+++ b/src/main/java/cpw/mods/inventorysorter/SortingHandler.java
@@ -113,12 +113,12 @@ public enum SortingHandler implements Consumer<ContainerContext>
             context.player.containerMenu.getSlot(slot).setChanged();
         }
     }
-    private void compactInventory(final ContainerContext context, final Multiset<ItemStackHolder> itemcounts)
-    {
-        final ResourceLocation containerTypeName = lookupContainerTypeName(context.player.inventoryMenu);
+    private void compactInventory(final ContainerContext context, final Multiset<ItemStackHolder> itemcounts) {
+        final ResourceLocation containerTypeName = lookupContainerTypeName(context.player.containerMenu);
+
         InventorySorter.INSTANCE.lastContainerType = containerTypeName;
         if (InventorySorter.INSTANCE.containerblacklist.contains(containerTypeName)) {
-            InventorySorter.INSTANCE.debugLog("Container {} blacklisted", ()->new String[] {containerTypeName.toString()});
+            InventorySorter.INSTANCE.debugLog("Container {} blacklisted", ()-> new String[] {containerTypeName.toString()});
             return;
         }
 

--- a/src/main/resources/META-INF/mods.toml
+++ b/src/main/resources/META-INF/mods.toml
@@ -1,26 +1,12 @@
-# This is an example mods.toml file. It contains the data relating to the loading mods.
-# There are several mandatory fields (#mandatory), and many more that are optional (#optional).
-# The overall format is standard TOML format, v0.5.0.
-# Note that there are a couple of TOML lists in this file.
-# Find more information on toml format here:  https://github.com/toml-lang/toml
-# The name of the mod loader type to load - for regular FML @Mod mods it should be javafml
-modLoader="javafml" #mandatory
-# A version range to match for said mod loader - for regular FML @Mod it will be the minecraft version (without the 1.)
-loaderVersion="[38,)" #mandatory
-# A text field displayed in the mod UI
-credits="cpw" #optional
-# A text field displayed in the mod UI
-authors="cpw" #optional
+modLoader="javafml"
+loaderVersion="[40,)"
+credits="cpw"
+authors="cpw"
 license="GPLv3"
-# A list of mods - how many allowed here is determined by the individual mod loader
-[[mods]] #mandatory
-    # The modid of the mod
-    modId="inventorysorter" #mandatory
-    # The version number of the mod - there's a few well known ${} variables useable here or just hardcode it
-    version="${file.jarVersion}" #mandatory
-     # A display name for the mod
-    displayName="Simple Inventory Sorter" #mandatory
-    # The description text for the mod (multi line!) (#mandatory)
+[[mods]]
+    modId="inventorysorter"
+    version="${file.jarVersion}"
+    displayName="Simple Inventory Sorter"
     description='''
 Simple inventory sorting.
 


### PR DESCRIPTION
> Required new branch for 1.18 before pulling

Fixes various issues found during testing
- Don't sort in spectator
- Fixed the container look up (`lookupContainerTypeName`) using the wrong container field on the player (using `inventoryMenu` instead of `containerMenu`
  - This also resolve the issue with the `showLast` command
- Fixed the `add blacklist` command giving the `RegistryKey` in the suggestions and not the `ResourceLocation`
- Fixed IMC being reset after a config load
  - Done via holding a separate IMC slot and container blacklist and avoiding committing them to the config as this is unneeded
- Updated to 1.18.2 and latest forge (just because)
- Minor code cleanup
- Added in the fixes from #150 although not tested

All seems to work as expected after testing each fix and double-checking they work nicely.