### PR TITLE
Call `Slot#set` instead of just `Slot#setChanged` after changing slot's item stack

### DIFF
--- a/src/main/java/cpw/mods/inventorysorter/ScrollWheelHandler.java
+++ b/src/main/java/cpw/mods/inventorysorter/ScrollWheelHandler.java
@@ -135,14 +135,7 @@ public enum ScrollWheelHandler implements Consumer<ContainerContext>
             if (iscopy.getCount() == 0)
             {
                 sourceStack.grow(-1);
-                if (sourceStack.getCount() == 0)
-                {
-                    source.set(ItemStack.EMPTY);
-                }
-                else
-                {
-                    source.setChanged();
-                }
+                source.set(sourceStack);
                 break;
             }
         }


### PR DESCRIPTION
The current implementation of `ScrollWheelHandler#accept` takes the `ItemStack` from the relevant slot and tries to insert it into other slots in the opened container. If insertion is successful, the stack's size is decreased by 1. If this results in the stack being empty, `Slot#set` is called with `ItemStack#EMPTY`, otherwise only `Slot#setChanged` is called.

This relies on the reference returned by `Slot#getItem()` staying relevant. If the returned stack is, for example, simply a copy, changes made to the stack won't be reflected in the container. This may be the case with `IItemHandler`s used in `SlotItemHandler`.
Additionally, vanilla always calls `Slot#set` with the updated item stack after changing a slot's contents. `Slot#set` will in turn also call `Slot#setChanged`.

This PR simply calls `Slot#set` with the updated stack. Since a stack with size <= 0 will return `true` for `ItemStack#isEmpty`, there should be no need to specifically return the `ItemStack#EMPTY` instance.